### PR TITLE
ci: fix sonar warning

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        with:
+          fetch-depth: 0
 
       - name: Setup node
         uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516
@@ -42,8 +44,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
-        with:
-          fetch-depth: 0
 
       - name: Setup node
         uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516


### PR DESCRIPTION
Uses a full clone instead of a shallow clone for sonar scan.